### PR TITLE
Add auto-refresh support to TaikunClient

### DIFF
--- a/example-project/autorefresh_token.py
+++ b/example-project/autorefresh_token.py
@@ -3,15 +3,15 @@ import taikunpy
 import json
 import time
 
-client_wrapper = taikunpy.TaikunClient(auto_refresh_minutes=1)  # refresh every 1 minute
+client_wrapper = taikunpy.TaikunClient()  # refresh every 1 minute
 client = client_wrapper.api_client
 
-user_info = taikunpycore.UsersApi(client).users_user_info()
-print("User Info:", user_info.data.username)
-print(json.dumps(client_wrapper.connection_info, indent=4))
+# user_info = taikunpycore.UsersApi(client).users_user_info()
+# print("User Info:", user_info.data.username)
+# print(json.dumps(client_wrapper.connection_info, indent=4))
 
 # Keep alive to see auto-refresh in action
 print("Waiting to observe token refreshes...")
-time.sleep(130)
+time.sleep(10000)
 
 client_wrapper.stop_auto_refresh()

--- a/example-project/autorefresh_token.py
+++ b/example-project/autorefresh_token.py
@@ -1,0 +1,17 @@
+import taikunpycore
+import taikunpy
+import json
+import time
+
+client_wrapper = taikunpy.TaikunClient(auto_refresh_minutes=1)  # refresh every 1 minute
+client = client_wrapper.api_client
+
+user_info = taikunpycore.UsersApi(client).users_user_info()
+print("User Info:", user_info.data.username)
+print(json.dumps(client_wrapper.connection_info, indent=4))
+
+# Keep alive to see auto-refresh in action
+print("Waiting to observe token refreshes...")
+time.sleep(130)
+
+client_wrapper.stop_auto_refresh()

--- a/example-project/autorefresh_token.py
+++ b/example-project/autorefresh_token.py
@@ -6,12 +6,14 @@ import time
 client_wrapper = taikunpy.TaikunClient()  # refresh every 1 minute
 client = client_wrapper.api_client
 
-# user_info = taikunpycore.UsersApi(client).users_user_info()
-# print("User Info:", user_info.data.username)
-# print(json.dumps(client_wrapper.connection_info, indent=4))
-
-# Keep alive to see auto-refresh in action
+user_info = taikunpycore.UsersApi(client).users_user_info()
+print("User Info:", user_info.data.username)
+print(json.dumps(client_wrapper.connection_info, indent=4))
 print("Waiting to observe token refreshes...")
-time.sleep(10000)
+time.sleep(500)
 
-client_wrapper.stop_auto_refresh()
+user_info = taikunpycore.UsersApi(client).users_user_info()
+print("User Info:", user_info.data.username)
+print(json.dumps(client_wrapper.connection_info, indent=4))
+print("Waiting to observe token refreshes...")
+time.sleep(500)

--- a/example-project/main.py
+++ b/example-project/main.py
@@ -17,4 +17,3 @@ print("User Info:", user_info.data.username)
 # Print json information about the available kubernetes profiles
 # list_k8sprofiles = taikunpycore.KubernetesProfilesApi(client).kubernetesprofiles_list(limit=1)
 # print(json.dumps(list_k8sprofiles.to_dict(), indent=4))
-

--- a/taikunpy/taikunpy/client.py
+++ b/taikunpy/taikunpy/client.py
@@ -1,24 +1,40 @@
 import os
-import taikunpycore
-from taikunpycore.rest import ApiException
+import threading
 from taikunpycore import Configuration, ApiClient
-from taikunpycore.api.auth_management_api import AuthManagementApi
+from taikunpycore.api import AuthManagementApi
 from taikunpycore.models import LoginCommand
+from taikunpycore.rest import ApiException
+
 
 class TaikunClient:
-    def __init__(self, api_host=None):
+    def __init__(self, api_host=None, auto_refresh_minutes=None):
         """Initialize the Taikun API Client and authenticate."""
+
+        # Store how often to auto-refresh the token (in minutes)
+        self.auto_refresh_minutes = auto_refresh_minutes
+        self._refresh_timer = None
+
+        # Determine the API host from argument or environment variable
         if api_host is None:
             self.api_host = 'https://' + os.getenv("TAIKUN_API_HOST", "api.taikun.cloud")
         else:
             self.api_host = 'https://' + api_host
 
+        # Token values will be set after authentication
         self.token = None
         self.refresh_token = None
+
+        # Create initial API client configuration
         self.configuration = Configuration()
         self.configuration.host = self.api_host
         self.api_client = ApiClient(self.configuration)
+
+        # Perform initial authentication
         self._authenticate()
+
+        # Start background auto-refresh if enabled
+        if self.auto_refresh_minutes:
+            self._start_auto_refresh()
 
     def _authenticate(self):
         """Authenticate the client using environment credentials."""
@@ -27,29 +43,63 @@ class TaikunClient:
         password = os.getenv("TAIKUN_PASSWORD")
         access_token = os.getenv("TAIKUN_ACCESS_KEY")
         secret_token = os.getenv("TAIKUN_SECRET_KEY")
+
+        # Create the API interface for authentication
         auth_api = AuthManagementApi(self.api_client)
 
         try:
-            if email and password and (auth_mode == "default" or auth_mode == '' ):
-                # Default mode (email/password authentication)
+            # Email/password auth (default mode)
+            if email and password and (auth_mode == "default" or auth_mode == ''):
                 response = auth_api.auth_login(LoginCommand(email=email, password=password))
+
+            # Token-based auth
             elif access_token and secret_token and auth_mode == "token":
-                # Token mode (access key and secret key authentication)
                 response = auth_api.auth_login(LoginCommand(accessKey=access_token, secretKey=secret_token, mode="token"))
+
+            # No valid credentials
             else:
                 raise ValueError("Valid authentication credentials must be provided.")
 
+            # Store tokens from the response
             self.token = response.token
             self.refresh_token = response.refresh_token
 
-            # Set authentication headers
+            # Apply token to the configuration for API authentication
             self.configuration.api_key["Bearer"] = self.token
             self.configuration.api_key_prefix["Bearer"] = "Bearer"
 
-            # Reinitialize client with new token
+            # Reinitialize the API client with updated headers
             self.api_client = ApiClient(self.configuration)
-            # print("Authenticated successfully!")
+
+            print("[TaikunClient] Authentication successful.")
 
         except ApiException as e:
-            print(f"Authentication failed: {e}")
+            print(f"[TaikunClient] Authentication failed: {e}")
 
+    def _start_auto_refresh(self):
+        """Start the background token refresh loop."""
+        def refresh_loop():
+            print("[TaikunClient] Auto-refreshing token...")
+            self._authenticate()  # Refresh the token
+            # Schedule next refresh
+            self._refresh_timer = threading.Timer(self.auto_refresh_minutes * 60, refresh_loop)
+            self._refresh_timer.daemon = True  # Won't block program from exiting
+            self._refresh_timer.start()
+
+        refresh_loop()  # Start the first refresh immediately
+
+    def stop_auto_refresh(self):
+        """Stop the auto-refresh background task."""
+        if self._refresh_timer:
+            self._refresh_timer.cancel()
+            print("[TaikunClient] Auto-refresh stopped.")
+
+    @property
+    def connection_info(self):
+        """Expose connection-related info (for debugging/logging)."""
+        return {
+            "api_host": self.api_host,
+            "token": self.token,
+            "refresh_token": self.refresh_token,
+            "configuration_host": self.configuration.host,
+        }

--- a/taikunpy/taikunpy/client.py
+++ b/taikunpy/taikunpy/client.py
@@ -7,11 +7,16 @@ from taikunpycore.rest import ApiException
 
 
 class TaikunClient:
-    def __init__(self, api_host=None, auto_refresh_minutes=None):
+    def __init__(self, api_host=None, auto_refresh_minutes=None):  # Default refresh to 5 minutes
         """Initialize the Taikun API Client and authenticate."""
 
         # Store how often to auto-refresh the token (in minutes)
-        self.auto_refresh_minutes = auto_refresh_minutes
+        if auto_refresh_minutes is None:
+            self.auto_refresh_minutes = 10
+            # print(self.auto_refresh_minutes)
+
+        else:
+            self.auto_refresh_minutes = auto_refresh_minutes
         self._refresh_timer = None
 
         # Determine the API host from argument or environment variable

--- a/taikunpy/taikunpy/client.py
+++ b/taikunpy/taikunpy/client.py
@@ -7,17 +7,13 @@ from taikunpycore.rest import ApiException
 
 
 class TaikunClient:
-    def __init__(self, api_host=None, auto_refresh_minutes=None):  # Default refresh to 5 minutes
+    def __init__(self, api_host=None, auto_refresh_minutes=5):  # Default refresh to 10 minutes
         """Initialize the Taikun API Client and authenticate."""
 
         # Store how often to auto-refresh the token (in minutes)
-        if auto_refresh_minutes is None:
-            self.auto_refresh_minutes = 10
-            # print(self.auto_refresh_minutes)
-
-        else:
-            self.auto_refresh_minutes = auto_refresh_minutes
         self._refresh_timer = None
+        if auto_refresh_minutes is not None:
+            self.auto_refresh_minutes = auto_refresh_minutes
 
         # Determine the API host from argument or environment variable
         if api_host is None:


### PR DESCRIPTION
This PR adds support for automatic token refreshing via a new `auto_refresh_minutes` parameter in `TaikunClient`.

✅ Features:
- Periodically re-authenticates using environment credentials
- `stop_auto_refresh()` method to clean up the background thread
- `connection_info` property for debugging token state

Let me know if you'd like to use the `refresh_token` endpoint instead of full re-login for refresh.
